### PR TITLE
fix: VIS pattern matching and commercial/extended WMI support

### DIFF
--- a/src/decoder.ts
+++ b/src/decoder.ts
@@ -35,6 +35,48 @@ const CHECK_DIGIT_POS = 8;
 const MODEL_YEAR_POS = 9;
 const PLANT_CODE_POS = 10;
 
+// Commercial vehicle WMIs - patterns often discontinued in federal submissions
+const COMMERCIAL_WMIS = new Set([
+  '1FD', '1FT', '2FD', '2FT', '3FD', '3FT',  // Ford heavy trucks
+  '1HT', '1HS', '2HT', '3HT',                 // International
+  '1GD', '1GB', '1GC', '2GD', '3GD',          // GM Commercial
+  '1FU', '1FV', '1FW', '3AL',                 // Freightliner
+  '1M1', '1M2', '1M3', '1M9',                 // Mack
+  '1NK', '1XK', '2NK', '3NK',                 // Kenworth
+  '1NP', '1XP', '2NP',                        // Peterbilt
+  '4V4', '4VZ',                               // Volvo Trucks
+  '5KK', '5KL',                               // Western Star
+  '1H2', '1H4', '5PV',                        // Hino
+  '4KL', '52N', 'JAL',                        // Isuzu Commercial
+  '1BA', '1BU',                               // Blue Bird (buses)
+]);
+
+// Extended WMI: small-volume manufacturers (<500 vehicles/year) use 6-char WMI
+// Format: positions 1-3 end in "9" + positions 12-14 form the full identifier
+const EXTENDED_WMI_PREFIXES = new Set([
+  '1A9', '1B9', '1C9', '1D9', '1E9', '1F9', '1G9', '1H9',
+  '1J9', '1K9', '1L9', '1M9', '1N9', '1P9', '1R9', '1S9',
+  '1T9', '1U9', '1V9', '1W9', '1X9', '1Y9', '1Z9',
+  '2A9', '2B9', '2C9', '2D9', '2E9', '2F9', '2G9', '2H9',
+  '2J9', '2K9', '2L9', '2M9', '2N9', '2P9', '2R9', '2S9',
+  '2T9', '2U9', '2V9', '2W9', '2X9', '2Y9', '2Z9',
+  '3A9', '3B9', '3C9', '3D9', '3E9', '3F9', '3G9', '3H9',
+  '3J9', '3K9', '3L9', '3M9', '3N9', '3P9', '3R9', '3S9',
+  '3T9', '3U9', '3V9', '3W9', '3X9', '3Y9', '3Z9',
+  '4A9', '4B9', '4C9', '4D9', '4E9', '4F9', '4G9', '4H9',
+  '4J9', '4K9', '4L9', '4M9', '4N9', '4P9', '4R9', '4S9',
+  '4T9', '4U9', '4V9', '4W9', '4X9', '4Y9', '4Z9',
+  '5A9', '5B9', '5C9', '5D9', '5E9', '5F9', '5G9', '5H9',
+  '5J9', '5K9', '5L9', '5M9', '5N9', '5P9', '5R9', '5S9',
+  '5T9', '5U9', '5V9', '5W9', '5X9', '5Y9', '5Z9',
+  '8A9', '8B9', '8C9', '8D9', '8E9', '8F9', '8G9', '8H9',
+  '8J9', '8K9', '8L9', '8M9', '8N9', '8P9', '8R9', '8S9',
+  '8T9', '8U9', '8V9', '8W9', '8X9', '8Y9', '8Z9',
+  '9A9', '9B9', '9C9', '9D9', '9E9', '9F9', '9G9', '9H9',
+  '9J9', '9K9', '9L9', '9M9', '9N9', '9P9', '9R9', '9S9',
+  '9T9', '9U9', '9V9', '9W9', '9X9', '9Y9', '9Z9',
+]);
+
 // Model year decoding (position 10)
 const YEAR_CODES: Record<string, number> = {
   A: 2010, B: 2011, C: 2012, D: 2013, E: 2014, F: 2015, G: 2016, H: 2017,
@@ -110,13 +152,19 @@ export class VINDecoder {
     }
 
     // Extract components
-    const wmi = vin.slice(0, 3);
+    const wmi3 = vin.slice(0, 3);
     const vds = vin.slice(3, 9);
     const vis = vin.slice(9, 17);
     const checkDigit = vin[CHECK_DIGIT_POS];
     const modelYearChar = vin[MODEL_YEAR_POS];
     const plantCode = vin[PLANT_CODE_POS];
     const serialNumber = vin.slice(11, 17);
+
+    // Extended WMI: small-volume manufacturers use 6-char WMI (pos 1-3 + pos 12-14)
+    const extendedWmi = EXTENDED_WMI_PREFIXES.has(wmi3)
+      ? wmi3 + vin.slice(11, 14)
+      : null;
+    const wmi = extendedWmi || wmi3;
 
     // Model year
     const modelYear = YEAR_CODES[modelYearChar];
@@ -149,11 +197,17 @@ export class VINDecoder {
       }
     }
 
-    // Get WMI info
-    const wmiMakes = this.wmiMakeIndex.get(wmi);
+    // Get WMI info - try extended WMI first, fall back to 3-char
+    let wmiMakes = extendedWmi ? this.wmiMakeIndex.get(extendedWmi) : undefined;
+    if (!wmiMakes || wmiMakes.length === 0) {
+      wmiMakes = this.wmiMakeIndex.get(wmi3);
+    }
 
-    // Get schemas for this WMI and year
-    const wmiSchemas = this.wmiSchemaIndex.get(wmi) || [];
+    // Get schemas for this WMI and year - try extended WMI first, fall back to 3-char
+    let wmiSchemas = extendedWmi ? (this.wmiSchemaIndex.get(extendedWmi) || []) : [];
+    if (wmiSchemas.length === 0) {
+      wmiSchemas = this.wmiSchemaIndex.get(wmi3) || [];
+    }
     const validSchemas = wmiSchemas.filter(s =>
       modelYear >= s.yearFrom && (s.yearTo === null || modelYear <= s.yearTo)
     );
@@ -172,14 +226,54 @@ export class VINDecoder {
 
     // Deduplicate and extract info
     const uniqueMatches = deduplicateMatches(allMatches);
-    const vehicle = this.extractVehicleInfo(uniqueMatches, wmiMakes, modelYear);
+    let vehicle = this.extractVehicleInfo(uniqueMatches, wmiMakes, modelYear);
     const engine = this.extractEngineInfo(uniqueMatches);
     const plant = this.extractPlantInfo(uniqueMatches, plantCode);
 
+    // Check for trailer/commercial fallback
+    const isTrailer = wmiMakes?.some(w => w.vehicleType === 'Trailer');
+    const isCommercial = COMMERCIAL_WMIS.has(wmi3);
+
+    // Trailer fallback: return partial decode from WMI
+    if (!vehicle && isTrailer && wmiMakes && wmiMakes.length > 0) {
+      const trailerInfo = wmiMakes[0];
+      vehicle = {
+        make: trailerInfo.manufacturer || trailerInfo.make || 'Unknown Trailer',
+        model: 'Trailer',
+        year: modelYear,
+        bodyType: 'Trailer',
+      };
+      warnings.push({
+        code: 'TRAILER_PARTIAL_DECODE',
+        message: 'Trailer VIN decoded from WMI only (VDS patterns not available)',
+      });
+    }
+
+    // Commercial vehicle fallback: return partial decode from WMI
+    if (!vehicle && isCommercial && wmiMakes && wmiMakes.length > 0) {
+      const commercialInfo = wmiMakes[0];
+      const vehicleType = commercialInfo.vehicleType || 'Commercial Vehicle';
+      vehicle = {
+        make: commercialInfo.make || commercialInfo.manufacturer || 'Unknown',
+        model: vehicleType,
+        year: modelYear,
+        bodyType: vehicleType,
+      };
+      warnings.push({
+        code: 'COMMERCIAL_PARTIAL_DECODE',
+        message: `Commercial vehicle decoded from WMI only (federal patterns discontinued for ${wmi3})`,
+      });
+    }
+
     // Calculate overall confidence
-    const confidence = uniqueMatches.length > 0
+    let confidence = uniqueMatches.length > 0
       ? uniqueMatches.reduce((sum, m) => sum + m.confidence, 0) / uniqueMatches.length
       : 0;
+
+    // Lower confidence for partial decodes
+    if ((isTrailer || isCommercial) && uniqueMatches.length === 0 && vehicle) {
+      confidence = 0.6;
+    }
 
     return {
       vin,
@@ -241,9 +335,25 @@ export class VINDecoder {
   ): DecodedVehicle | undefined {
     const info: Partial<DecodedVehicle> = { year: modelYear };
 
-    // Get make from WMI lookup first
+    // Get make from WMI lookup - select correct make when multiple exist
     if (wmiMakes && wmiMakes.length > 0) {
-      info.make = wmiMakes[0].make;
+      if (wmiMakes.length === 1) {
+        info.make = wmiMakes[0].make;
+      } else {
+        // Multiple makes for this WMI - match make name to manufacturer name
+        const manufacturer = wmiMakes[0].manufacturer?.toUpperCase() || '';
+        const matched = wmiMakes.find(wm =>
+          wm.make && manufacturer.includes(wm.make.toUpperCase())
+        );
+        if (matched) {
+          info.make = matched.make;
+        } else if (wmiMakes[0].manufacturer) {
+          // Use manufacturer name as make
+          info.make = wmiMakes[0].manufacturer;
+        } else {
+          info.make = wmiMakes[0].make;
+        }
+      }
     }
 
     for (const match of matches) {

--- a/src/pattern-matcher.ts
+++ b/src/pattern-matcher.ts
@@ -77,15 +77,31 @@ function parsePattern(pattern: string): string[] {
 
 /**
  * Check if input matches pattern
+ * For VIS patterns (e.g., "BFGFF|*A"), input is fullInput (VDS+VIS = 14 chars)
+ * Layout: [0-4]=VDS, [5]=check, [6]=year, [7]=plant, [8-13]=serial
  */
 export function matchesPattern(input: string, pattern: string): boolean {
-  // Handle VIS patterns with pipe separator (e.g., "*****|*U")
+  // Handle VIS patterns with pipe separator (e.g., "BFGFF|*A")
   const [vdsPattern, visPattern] = pattern.split('|');
 
   if (visPattern) {
-    // VIS pattern - match against input which should be plant code char
-    const plantCodePattern = visPattern[1]; // Second char after *
-    return plantCodePattern === '*' || input[0] === plantCodePattern;
+    // VIS pattern - must verify BOTH VDS and plant code
+    // input layout: VDS(5) + check(1) + year(1) + plant(1) + serial(6) = 14 chars
+
+    // First verify VDS portion (first 5 chars)
+    if (vdsPattern !== '*****') {
+      const vdsSegments = parsePattern(vdsPattern);
+      for (let i = 0; i < vdsSegments.length && i < 5; i++) {
+        if (!charMatches(input[i], vdsSegments[i])) {
+          return false;
+        }
+      }
+    }
+
+    // Then check plant code (position 7 in fullInput = position 11 in VIN)
+    const plantCodePattern = visPattern[1];
+    const plantCode = input[7];
+    return plantCodePattern === '*' || plantCode === plantCodePattern;
   }
 
   // Standard VDS pattern
@@ -107,24 +123,37 @@ export function matchesPattern(input: string, pattern: string): boolean {
 /**
  * Calculate confidence score for a pattern match
  * Higher score = more specific pattern
+ * For VIS patterns, input is fullInput (VDS+VIS = 14 chars)
  */
 export function calculateConfidence(input: string, pattern: string): number {
-  const [actualPattern, visPattern] = pattern.split('|');
+  const [vdsPattern, visPattern] = pattern.split('|');
 
-  // VIS patterns (plant codes)
+  // VIS patterns (plant codes) - must verify VDS matches first
   if (visPattern) {
+    // Verify VDS portion matches (first 5 chars)
+    if (vdsPattern !== '*****') {
+      const vdsSegments = parsePattern(vdsPattern);
+      for (let i = 0; i < vdsSegments.length && i < 5; i++) {
+        if (!charMatches(input[i], vdsSegments[i])) {
+          return 0;
+        }
+      }
+    }
+
+    // Then check plant code (position 7 = VIN position 11)
     const plantCodePattern = visPattern[1];
+    const plantCode = input[7];
     if (plantCodePattern === '*') return 0.8;
-    if (input[0] === plantCodePattern) return 1.0;
+    if (plantCode === plantCodePattern) return 1.0;
     return 0;
   }
 
   // Standard pattern
-  if (!matchesPattern(input, actualPattern)) {
+  if (!matchesPattern(input, vdsPattern)) {
     return 0;
   }
 
-  const segments = parsePattern(actualPattern);
+  const segments = parsePattern(vdsPattern);
   let exactMatches = 0;
   let classMatches = 0;
   let wildcardMatches = 0;
@@ -172,11 +201,9 @@ export function matchPatterns(
   const matches: PatternMatch[] = [];
 
   for (const lookup of lookups) {
-    const isVISPattern = lookup.pattern.includes('|');
-
-    // Calculate confidence
-    const patternInput = isVISPattern ? vis : fullInput;
-    const confidence = calculateConfidence(patternInput, lookup.pattern);
+    // Calculate confidence - always use fullInput for both VDS and VIS patterns
+    // VIS patterns need full context to verify VDS portion before checking plant code
+    const confidence = calculateConfidence(fullInput, lookup.pattern);
 
     // Apply threshold (lower for plant codes)
     const threshold = lookup.elementCode.toLowerCase().includes('plant')
@@ -187,8 +214,8 @@ export function matchPatterns(
 
     // Calculate positions
     const positions: number[] = [];
-    const [actualPattern] = lookup.pattern.split('|');
-    const startPos = isVISPattern ? 9 : 3;
+    const [actualPattern, hasVisPattern] = lookup.pattern.split('|');
+    const startPos = hasVisPattern !== undefined ? 9 : 3;
 
     for (let i = 0; i < actualPattern.length; i++) {
       if (actualPattern[i] !== '|') {

--- a/test/pattern-matcher.test.ts
+++ b/test/pattern-matcher.test.ts
@@ -37,9 +37,18 @@ describe('Pattern Matching', () => {
     });
 
     it('should handle VIS patterns with pipe separator', () => {
-      expect(matchesPattern('U', '*****|*U')).toBe(true);
-      expect(matchesPattern('A', '*****|*U')).toBe(false);
-      expect(matchesPattern('X', '*****|**')).toBe(true); // wildcard
+      // VIS patterns use fullInput: VDS(5) + check(1) + year(1) + plant(1) + serial(6) = 14 chars
+      // Layout: [0-4]=VDS, [5]=check, [6]=year, [7]=plant, [8-13]=serial
+      // Pattern *****|*U = any VDS, any year, plant must be U
+      expect(matchesPattern('ABCDE00U000000', '*****|*U')).toBe(true);
+      expect(matchesPattern('ABCDE00A000000', '*****|*U')).toBe(false);
+      expect(matchesPattern('ABCDE00X000000', '*****|**')).toBe(true); // wildcard plant
+
+      // Pattern BFGFF|*A = VDS must be BFGFF, any year, plant must be A
+      expect(matchesPattern('BFGFF00A000000', 'BFGFF|*A')).toBe(true);
+      expect(matchesPattern('BFGFF0NA000000', 'BFGFF|*A')).toBe(true); // any year
+      expect(matchesPattern('BFGFF00U000000', 'BFGFF|*A')).toBe(false); // wrong plant
+      expect(matchesPattern('XXXXX00A000000', 'BFGFF|*A')).toBe(false); // wrong VDS
     });
   });
 
@@ -59,8 +68,13 @@ describe('Pattern Matching', () => {
     });
 
     it('should handle VIS patterns', () => {
-      expect(calculateConfidence('U', '*****|*U')).toBe(1.0);
-      expect(calculateConfidence('X', '*****|**')).toBe(0.8); // wildcard
+      // VIS patterns use fullInput (14 chars): [0-4]=VDS, [5]=check, [6]=year, [7]=plant
+      expect(calculateConfidence('ABCDE00U000000', '*****|*U')).toBe(1.0);
+      expect(calculateConfidence('ABCDE00X000000', '*****|**')).toBe(0.8); // wildcard plant
+
+      // VDS must also match for non-wildcard VDS patterns
+      expect(calculateConfidence('BFGFF00A000000', 'BFGFF|*A')).toBe(1.0);
+      expect(calculateConfidence('XXXXX00A000000', 'BFGFF|*A')).toBe(0); // VDS mismatch
     });
   });
 


### PR DESCRIPTION
## Summary
- **VIS pattern bug fix**: Patterns like `SP3V3|*M` now verify both VDS and plant code (was ignoring VDS portion, causing false positives)
- **Extended WMI support**: Small-volume manufacturers use 6-char WMI (e.g., `VF9795` for Bugatti)
- **Commercial vehicle fallback**: Returns partial decode from WMI when federal VDS patterns unavailable
- **WMI make disambiguation**: Correctly selects make when multiple makes share a WMI

## Examples

**VIS Pattern Fix** (e.g., Tesla plant codes)
```
Pattern: *****|*F (any VDS, plant=F for Fremont)

Before: Only checked plant position, could match wrong VDS
After:  Verifies full VDS+plant context from positions 3-11
```

**Extended WMI** (small-volume manufacturers)
```
WMI: VF9795 = Bugatti Automobiles S.A.S
     1F9434 = Fulmer Fabrications
     1M9667 = Motorcycle Machine Shop Services

VIN positions: 1-3 (VF9) + 12-14 (795) → full 6-char identifier
```

**Commercial Vehicle Fallback**
```
VIN: 1FTEW2LP1SKE69114 (Ford F-150)
     1FD0W5HT7NED58552 (Ford Super Duty)

WMI 1FT/1FD → Ford, partial decode with COMMERCIAL_PARTIAL_DECODE warning
when federal patterns discontinued
```

## Test plan
- [x] Unit tests updated for VIS pattern matching with full input context
- [ ] Run decoder against commercial VINs from benchmark-vins.txt
- [ ] Verify extended WMI decoding (Bugatti VF9795, etc.)